### PR TITLE
chore(ci): pin GitHub Actions to SHA + Dependabot cooldown (supply-chain)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     name: TypeScript typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 


### PR DESCRIPTION
## Contexte

Rollout supply-chain Bastion code-security (severity High), même traitement que le template askara-symfony#2207 : `github-actions-mutable-action-tag` + `dependabot-missing-cooldown`.

## Changements

- **Pin SHA** : chaque `uses: x@vN` non-pinné → `x@<sha> # vN` (via `pin-github-action`). Résidus non-pinnés = 0. Lécosystème `github-actions` de Dependabot maintient les SHAs à jour.
- **Cooldown** : `cooldown.default-days: 7` sur les entrées `dependabot.yml` (là où présent).

_CI-workflow/dependabot YAML uniquement — aucun code applicatif touché._

https://claude.ai/code/session_011WiHj7nX2U4BXJgbfUDQ65