### PR TITLE
chore(security): ASK-3513 pin GitHub Actions to SHA + Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 7
     directory: "/"
     schedule:
       interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     name: TypeScript typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 


### PR DESCRIPTION
Bastion SAST remediation — compliance test `bastion-code-security-issues` (ASK-3513).

Pin CI actions to full commit SHAs + add a 7-day Dependabot cooldown. Fork-local change (targets askara-ai/update-electron-app, not the electron/ upstream). No functional change.

https://claude.ai/code/session_019tJzR7BFQQdPDhiNx5hyTN